### PR TITLE
Add support for upstream servers using HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ mechanic update mysite --backends=192.168.1.2:3000,192.168.1.2:3001,192.168.1.3:
 
 *You can use hostnames too.*
 
+### Secure backends
+
+If you're proxying to a remote server, it's a good idea to enable HTTPS there too, so your connection is secure end-to-end. If you use the `https-upstream` option, nginx will make requests to your backends using SSL.
+
+```
+mechanic update mysite --https-upstream
+```
+
+Note that this can introduce a significant performance overhead, as nginx will need to validate certificates and encrypt the connection with the backend.
+
 ## Secure sites
 
 Now we've added ecommerce and we need a secure site:

--- a/app.js
+++ b/app.js
@@ -56,7 +56,8 @@ var options = {
   'static': 'string',
   'autoindex': 'boolean',
   'https': 'boolean',
-  'redirect-to-https': 'boolean'
+  'redirect-to-https': 'boolean',
+  'https-upstream': 'boolean'
 };
 
 var parsers = {

--- a/template.conf
+++ b/template.conf
@@ -38,8 +38,15 @@
       {# We need a named location block in order to use try_files. #}
       {% if site.backends.length %}
         location @proxy-{{ site.shortname }}-{{ options.port }} {
-          proxy_pass http://upstream-{{ site.shortname }};
-      
+          {% if site['https-upstream'] %}
+            proxy_pass https://upstream-{{ site.shortname }};
+            proxy_ssl_verify on;
+            proxy_ssl_session_reuse on;
+            proxy_ssl_protocols TLSv1.1 TLSv1.2;
+          {% else %}
+            proxy_pass http://upstream-{{ site.shortname }};
+          {% endif %}
+
           proxy_next_upstream error timeout invalid_header http_500 http_502
         http_503 http_504;
           proxy_redirect off;

--- a/template.conf
+++ b/template.conf
@@ -40,7 +40,6 @@
         location @proxy-{{ site.shortname }}-{{ options.port }} {
           {% if site['https-upstream'] %}
             proxy_pass https://upstream-{{ site.shortname }};
-            proxy_ssl_verify on;
             proxy_ssl_session_reuse on;
             proxy_ssl_protocols TLSv1.1 TLSv1.2;
           {% else %}


### PR DESCRIPTION
This adds a flag: `--https-upstream` to specify the upstream server(s) are using https. This can ensure the connection remains secure even if you're proxying to a remote server.

I know it's not in everyone's use-case, but I needed it almost immediately.